### PR TITLE
Value needs to be a string in put_resp_header/3

### DIFF
--- a/lib/plug_cors/actual.ex
+++ b/lib/plug_cors/actual.ex
@@ -17,7 +17,7 @@ defmodule PlugCors.Actual do
         conn = conn |> put_resp_header("access-control-allow-origin", origin)
 
         if config[:supports_credentials] do
-          conn = put_resp_header(conn, "access-control-allow-credentials", true)
+          conn = put_resp_header(conn, "access-control-allow-credentials", "true")
         end
 
         if Enum.count(config[:expose_headers]) > 0 do

--- a/lib/plug_cors/preflight.ex
+++ b/lib/plug_cors/preflight.ex
@@ -105,7 +105,7 @@ defmodule PlugCors.Preflight do
     end
 
     if config[:supports_credentials] do
-      conn = put_resp_header(conn, "access-control-allow-credentials", true)
+      conn = put_resp_header(conn, "access-control-allow-credentials", "true")
     end
 
     if Enum.count(config[:expose_headers]) > 0 do


### PR DESCRIPTION
I was getting a no-match error. Turns out that plug.conn expects the value and the key to be a string. https://github.com/elixir-lang/plug/blob/master/lib/plug/conn.ex#L397