### PR TITLE
Check if origin header had a host at all

### DIFF
--- a/lib/plug_cors.ex
+++ b/lib/plug_cors.ex
@@ -100,7 +100,7 @@ defmodule PlugCors do
         String.contains?(origin_to_test, domain)
       _ ->
         origin_to_test = URI.parse(origin_to_test).host
-        String.downcase(origin_to_test) == String.downcase(allowed_origin)
+        not is_nil(origin_to_test) and String.downcase(origin_to_test) == String.downcase(allowed_origin)
     end
   end
 end


### PR DESCRIPTION
`URI.parse(origin_to_test).host` returns `nil` when the `Origin` header was present but had an empty string for a value. The `String.downcase/1` call on the next line crashes with `nil` as input:

```
** (FunctionClauseError) no function clause matching in String.Unicode.downcase/2
    (elixir) unicode/unicode.ex:49: String.Unicode.downcase(nil, "")
```

This adds an `is_nil/1` check that rejects the origin before the string comparison if needed.
